### PR TITLE
It may throw a exception in CefInitializer

### DIFF
--- a/jcefmaven/src/main/java/me/friwi/jcefmaven/impl/step/init/CefInitializer.java
+++ b/jcefmaven/src/main/java/me/friwi/jcefmaven/impl/step/init/CefInitializer.java
@@ -36,8 +36,12 @@ public class CefInitializer {
             SystemBootstrap.setLoader(libname -> {
             });
 
-            //Load native libraries for jcef, as the jvm does not update the java library path
-            System.loadLibrary("jawt");
+            try {
+                // Load native libraries for jcef, as the jvm does not update the java library path
+                System.loadLibrary("jawt");
+            } catch (UnsatisfiedLinkError e) {
+                // ignore it
+            }
 
             //Platform dependent loading code
             if (EnumPlatform.getCurrentPlatform().getOs().isWindows()) {

--- a/jcefmaven/src/main/java/me/friwi/jcefmaven/impl/step/init/CefInitializer.java
+++ b/jcefmaven/src/main/java/me/friwi/jcefmaven/impl/step/init/CefInitializer.java
@@ -43,7 +43,7 @@ public class CefInitializer {
                 // Load native libraries for jcef, as the jvm does not update the java library path
                 System.loadLibrary("jawt");
             } catch (UnsatisfiedLinkError e) {
-                LOGGER.warning("A error thrown while loading jawt library!")
+                LOGGER.warning("A error thrown while loading jawt library: " + e.getMessage())
             }
 
             //Platform dependent loading code

--- a/jcefmaven/src/main/java/me/friwi/jcefmaven/impl/step/init/CefInitializer.java
+++ b/jcefmaven/src/main/java/me/friwi/jcefmaven/impl/step/init/CefInitializer.java
@@ -17,6 +17,9 @@ import java.util.Objects;
  * @author Fritz Windisch
  */
 public class CefInitializer {
+    
+    private static final Logger LOGGER = Logger.getLogger(CefInitializer.class.getName());
+    
     private static final String JAVA_LIBRARY_PATH = "java.library.path";
 
     public static CefApp initialize(File installDir, List<String> cefArgs, CefSettings cefSettings) throws UnsupportedPlatformException, CefInitializationException {
@@ -40,7 +43,7 @@ public class CefInitializer {
                 // Load native libraries for jcef, as the jvm does not update the java library path
                 System.loadLibrary("jawt");
             } catch (UnsatisfiedLinkError e) {
-                // ignore it
+                LOGGER.warning("A error thrown while loading jawt library!")
             }
 
             //Platform dependent loading code

--- a/jcefmaven/src/main/java/me/friwi/jcefmaven/impl/step/init/CefInitializer.java
+++ b/jcefmaven/src/main/java/me/friwi/jcefmaven/impl/step/init/CefInitializer.java
@@ -43,7 +43,7 @@ public class CefInitializer {
                 // Load native libraries for jcef, as the jvm does not update the java library path
                 System.loadLibrary("jawt");
             } catch (UnsatisfiedLinkError e) {
-                LOGGER.warning("A error thrown while loading jawt library: " + e.getMessage())
+                LOGGER.warning("Error while loading jawt library: " + e.getMessage())
             }
 
             //Platform dependent loading code


### PR DESCRIPTION
When I trying to use CefAppBuilder to make a gui for my Minecraft Mod, it throws a exception.
I think make a try catch covers it can fix this issue
~~~
Exception in thread "Thread-15" [16:15:00] [Thread-15/INFO]: [java.lang.ThreadGroup:uncaughtException:1052]: java.lang.UnsatisfiedLinkError: Native Library /usr/lib/jvm/java-8-adoptopenjdk/jre/lib/amd64/libjawt.so already loaded in another classloader
[16:15:00] [Thread-15/INFO]: [java.lang.ThreadGroup:uncaughtException:1052]: 	at java.lang.ClassLoader.loadLibrary0(ClassLoader.java:1900)
[16:15:00] [Thread-15/INFO]: [java.lang.ThreadGroup:uncaughtException:1052]: 	at java.lang.ClassLoader.loadLibrary(ClassLoader.java:1838)
[16:15:00] [Thread-15/INFO]: [java.lang.ThreadGroup:uncaughtException:1052]: 	at java.lang.Runtime.loadLibrary0(Runtime.java:871)
[16:15:00] [Thread-15/INFO]: [java.lang.ThreadGroup:uncaughtException:1052]: 	at java.lang.System.loadLibrary(System.java:1124)
[16:15:00] [Thread-15/INFO]: [java.lang.ThreadGroup:uncaughtException:1052]: 	at me.friwi.jcefmaven.impl.step.init.CefInitializer.initialize(CefInitializer.java:40)
[16:15:00] [Thread-15/INFO]: [java.lang.ThreadGroup:uncaughtException:1052]: 	at me.friwi.jcefmaven.CefAppBuilder.build(CefAppBuilder.java:233)
[16:15:00] [Thread-15/INFO]: [java.lang.ThreadGroup:uncaughtException:1052]: 	at net.ccbluex.liquidbounce.ui.cef.CefRenderManager.initialize(CefRenderManager.kt:36)
[16:15:00] [Thread-15/INFO]: [java.lang.ThreadGroup:uncaughtException:1052]: 	at net.ccbluex.liquidbounce.ui.cef.CefRenderManager$initializeAsync$1.invoke(CefRenderManager.kt:21)
[16:15:00] [Thread-15/INFO]: [java.lang.ThreadGroup:uncaughtException:1052]: 	at net.ccbluex.liquidbounce.ui.cef.CefRenderManager$initializeAsync$1.invoke(CefRenderManager.kt:20)
[16:15:00] [Thread-15/INFO]: [java.lang.ThreadGroup:uncaughtException:1052]: 	at kotlin.concurrent.ThreadsKt$thread$thread$1.run(Thread.kt:30)
~~~