### PR TITLE
I think install.lock should be like this

### DIFF
--- a/jcefmaven/src/main/java/me/friwi/jcefmaven/CefAppBuilder.java
+++ b/jcefmaven/src/main/java/me/friwi/jcefmaven/CefAppBuilder.java
@@ -181,6 +181,11 @@ public class CefAppBuilder {
             //Clear install dir
             FileUtils.deleteDir(this.installDir);
             if (!this.installDir.mkdirs()) throw new IOException("Could not create installation directory");
+            //Lock installation
+            File installLock = new File(installDir, "install.lock");
+            if (!(installLock.createNewFile())) {
+                throw new IOException("Could not create install.lock to complete installation");
+            }
             //Fetch a native input stream
             InputStream nativesIn = PackageClasspathStreamer.streamNatives(
                     CefBuildInfo.fromClasspath(), EnumPlatform.getCurrentPlatform());
@@ -221,9 +226,8 @@ public class CefAppBuilder {
             if (EnumPlatform.getCurrentPlatform().getOs().isMacOSX()) {
                 UnquarantineUtil.unquarantine(this.installDir);
             }
-            //Lock installation
-            if (!(new File(installDir, "install.lock").createNewFile())) {
-                throw new IOException("Could not create install.lock to complete installation");
+            if(!(installLock.delete())) {
+                throw new IOException("Could not remove install.lock");
             }
         }
         this.progressHandler.handleProgress(EnumProgress.INITIALIZING, EnumProgress.NO_ESTIMATION);


### PR DESCRIPTION
If create `install.lock` when install complete, it will force reinstall natives every time build the CefApp.
I think `install.lock` is a check for is the installtion complete