### PR TITLE
Fix potential race condition

### DIFF
--- a/jcefmaven/src/main/java/me/friwi/jcefmaven/CefAppBuilder.java
+++ b/jcefmaven/src/main/java/me/friwi/jcefmaven/CefAppBuilder.java
@@ -202,8 +202,8 @@ public class CefAppBuilder {
                 }
                 return this.instance;
             }
+            this.building = true;
         }
-        this.building = true;
         this.progressHandler.handleProgress(EnumProgress.LOCATING, EnumProgress.NO_ESTIMATION);
         boolean installOk = CefInstallationChecker.checkInstallation(this.installDir);
         if (!installOk) {


### PR DESCRIPTION
`CefAppBuilder.build()` is intended to be thread-safe, however, there's a very, very slim chance that this may not always be the case. This pull request fixes that.

---

Just in case the reasoning of the fix isn't clear, consider the old code before the fix:

Consider two threads running in parallel in a multi-core CPU, with both threads calling `CefAppBuilder.build()` and reaching `synchronized (lock)` at the same time. Now, only one thread was permitted to pass, let's name it _thread **A**_, while the other was suspended, let's name that _thread **B**_. Thread **A** saw `building == false`, and so proceeds: it exited the `synchronized` block and is now about to run `this.building = true;`, but, in an extremely unfortunate scenario, it is not able to do so right away, as the CPU core where thread **A** is running got busy by other requests from the OS, and so, thread **A** is now suspended (not by the JVM, but by the OS itself). However, no one is holding the lock anymore, and so, thread **B** may now proceed, running in its own CPU core: it will also see `building == false`. But, thread **A** got resumed right away too, and so now, you have a scenario where both threads are trying to initialize and install CEF: both saw `building == false`, both runs `this.building = true;` and so on.

---

P.S. Also, just in case, beware of [double-checked locking in Java](https://en.wikipedia.org/wiki/Double-checked_locking#Usage_in_Java). In your current setup however, it's not a problem (I believe).