### PR TITLE
Break out install method so it can be called on its own

### DIFF
--- a/jcefmaven/pom.xml
+++ b/jcefmaven/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.friwi</groupId>
     <artifactId>jcefmaven</artifactId>
-    <version>105.3.36.1</version>
+    <version>108.4.13</version>
 
     <packaging>jar</packaging>
     <name>JCef Maven</name>
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>me.friwi</groupId>
             <artifactId>jcef-api</artifactId>
-            <version>jcef-6a2f6c0+cef-105.3.36+g88e0038+chromium-105.0.5195.102</version>
+            <version>jcef-c1f0745+cef-108.4.13+ga98cd4c+chromium-108.0.5359.125</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
We have a need in our app to do the install outside of actually wanted CEF to be initialized. I simply moved the install logic into its own method so it can be called separately.