### PR TITLE
Support an ordered collection of Mirrors

### DIFF
--- a/jcefmaven/src/main/java/me/friwi/jcefmaven/CefAppBuilder.java
+++ b/jcefmaven/src/main/java/me/friwi/jcefmaven/CefAppBuilder.java
@@ -61,7 +61,7 @@ public class CefAppBuilder {
     private CefApp instance = null;
     private boolean building = false;
     private boolean installed = false;
-    private final Set<String> mirrors;
+    private final List<String> mirrors;
 
     /**
      * Constructs a new CefAppBuilder instance.
@@ -72,7 +72,7 @@ public class CefAppBuilder {
         jcefArgs = new LinkedList<>();
         jcefArgs.addAll(DEFAULT_JCEF_ARGS);
         cefSettings = DEFAULT_CEF_SETTINGS.clone();
-        mirrors = new HashSet<>();
+        mirrors = new ArrayList<>();
         mirrors.add("https://github.com/jcefmaven/jcefmaven/releases/download/{mvn_version}/jcef-natives-{platform}-{tag}.jar");
         mirrors.add("https://repo.maven.apache.org/maven2/me/friwi/jcef-natives-{platform}/{tag}/jcef-natives-{platform}-{tag}.jar");
     }
@@ -160,7 +160,7 @@ public class CefAppBuilder {
      * @return A copy of all mirrors that are currently in use. First element will be attempted first.
      */
     public Collection<String> getMirrors() {
-        return new HashSet<>(mirrors);
+        return new ArrayList<>(mirrors);
     }
 
     /**
@@ -227,9 +227,8 @@ public class CefAppBuilder {
                     File download = new File(this.installDir, "download.zip.temp");
                     PackageDownloader.downloadNatives(
                             CefBuildInfo.fromClasspath(), EnumPlatform.getCurrentPlatform(),
-                            download, f -> {
-                                this.progressHandler.handleProgress(EnumProgress.DOWNLOADING, f);
-                            }, mirrors);
+                            download, f -> this.progressHandler.handleProgress(EnumProgress.DOWNLOADING, f),
+                            getMirrors());
                     nativesIn = new ZipInputStream(new FileInputStream(download));
                     ZipEntry entry;
                     boolean found = false;

--- a/jcefmaven/src/main/java/me/friwi/jcefmaven/impl/step/fetch/PackageDownloader.java
+++ b/jcefmaven/src/main/java/me/friwi/jcefmaven/impl/step/fetch/PackageDownloader.java
@@ -7,9 +7,9 @@ import me.friwi.jcefmaven.EnumPlatform;
 import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -27,7 +27,7 @@ public class PackageDownloader {
     private static final int BUFFER_SIZE = 16 * 1024;
 
     public static void downloadNatives(CefBuildInfo info, EnumPlatform platform, File destination,
-                                       Consumer<Float> progressConsumer, Set<String> mirrors) throws IOException {
+                                       Consumer<Float> progressConsumer, Collection<String> mirrors) throws IOException {
         Objects.requireNonNull(info, "info cannot be null");
         Objects.requireNonNull(platform, "platform cannot be null");
         Objects.requireNonNull(destination, "destination cannot be null");


### PR DESCRIPTION
Store the mirrors in an ordered collection instead of a Set, so the sequence can be retained when passing them to `PackageDownloader.downloadNatives`

Fixes #109 