### PR TITLE
jogl v2.4.0-rc-20210111 -> v2.4.0-rc

### DIFF
--- a/scripts/set_build_info.sh
+++ b/scripts/set_build_info.sh
@@ -16,7 +16,7 @@ echo "Initializing for build from $1 for $2..."
 export $(curl -s -L $1 | jq -r "to_entries|map(\"\(.key)=\(.value|tostring)\")|.[]")
 
 #Set JOGL information
-export jogl_build=v2.4.0-rc-20210111
+export jogl_build=v2.4.0
 export jogl_download=https://jogamp.org/deployment/$jogl_build/jar #Without terminating /!
 export jogl_git=https://jogamp.org/cgit/jogl.git
 export jogl_commit=ecf6e499d3b582d651a28693c871ca14d6e8c991 #From META-INF


### PR DESCRIPTION
Replaces jogl version with a non-rc version.
Should fix #121 